### PR TITLE
Fixed error on missing 'xxd' executable

### DIFF
--- a/lua/hex/utils.lua
+++ b/lua/hex/utils.lua
@@ -3,23 +3,23 @@ local M = {}
 function M.drop_undo_history()
   local undolevels = vim.o.undolevels
   vim.o.undolevels = -1
-  vim.cmd [[exe "normal a \<BS>\<Esc>"]]
+  vim.cmd([[exe "normal a \<BS>\<Esc>"]])
   vim.o.undolevels = undolevels
 end
 
 function M.dump_to_hex(hex_dump_cmd)
   vim.b.hex = true
-  vim.cmd([[%! ]]..hex_dump_cmd)
+  vim.cmd([[%! ]] .. hex_dump_cmd)
   vim.b.hex_ft = vim.bo.ft
-  vim.bo.ft = 'xxd'
+  vim.bo.ft = "xxd"
   M.drop_undo_history()
   -- FIXME: this can be problematic
-  vim.cmd [[LspStop]]
+  vim.cmd([[LspStop]])
   vim.bo.mod = false
 end
 
 function M.assemble_from_hex(hex_assemble_cmd)
-  vim.cmd([[%! ]]..hex_assemble_cmd)
+  vim.cmd([[%! ]] .. hex_assemble_cmd)
   vim.bo.ft = vim.b.hex_ft
   M.drop_undo_history()
   vim.bo.mod = false
@@ -28,23 +28,23 @@ end
 
 function M.begin_patch_from_hex(hex_assemble_cmd)
   vim.b.hex_cur_pos = vim.fn.getcurpos()
-  vim.cmd([[%! ]]..hex_assemble_cmd)
+  vim.cmd([[%! ]] .. hex_assemble_cmd)
 end
 
 function M.finish_patch_from_hex(hex_dump_cmd)
-  vim.cmd([[%! ]]..hex_dump_cmd)
-  vim.fn.setpos('.', vim.b.hex_cur_pos)
+  vim.cmd([[%! ]] .. hex_dump_cmd)
+  vim.fn.setpos(".", vim.b.hex_cur_pos)
   vim.bo.mod = true
 end
 
 function M.is_program_on_path(program)
-  local exit_code = os.execute('which '..program)
-  
-  if (exit_code == 0) then
+  local exit_code = os.execute("which " .. program)
+  if exit_code then
     return true
+  else
+    vim.notify(program .. " is not installed on this system, aborting!", vim.log.levels.ERROR)
+    return false
   end
-  vim.notify(program .. " is not installed on this system, aborting!", vim.log.levels.ERROR)
-  return false
 end
 
 return M


### PR DESCRIPTION
Hi there,
Thanks for the amazing plugin! 
I noticed that it gave me errors on missing `xxd`, which was weird, as it was installed and lua was also reporting it as in PATH. Adjusted plugin source code to only return, if exit code is false.
Cheers!