### PR TITLE
[fix] Buffer Dump

### DIFF
--- a/lua/hex/utils.lua
+++ b/lua/hex/utils.lua
@@ -9,7 +9,7 @@ end
 
 function M.dump_to_hex(hex_dump_cmd)
   vim.b.hex = true
-  vim.cmd([[%! ]] .. hex_dump_cmd)
+  vim.cmd([[%! ]] .. hex_dump_cmd .. " " .. vim.fn.expand('%:p'))
   vim.b.hex_ft = vim.bo.ft
   vim.bo.ft = 'xxd'
   M.drop_undo_history()


### PR DESCRIPTION
It seems that `xxd` does not work well when omitting the input/output file.
HexDump and using "%! xxd -g 1 -u" direclty appears to randomly insert characters.
Explicitly providing the file name fixes the hex dump.

This partially fixes [Issue #6 ](https://github.com/RaafatTurki/hex.nvim/issues/6).

Attempts to save the buffer still results in a broken binary file.
I presume the `xxd` has the same issue when assembling the hex file if the input file is omitted.

Not sure how to best solve that issue.
Maybe save the hex dump to a tmp file and then use something like:

```
hexdump -r <tmp.file> <binary>
```