### PR TITLE
fix(paths): Use quotes around file paths

### DIFF
--- a/lua/hex/utils.lua
+++ b/lua/hex/utils.lua
@@ -9,7 +9,7 @@ end
 
 function M.dump_to_hex(hex_dump_cmd)
   vim.b.hex = true
-  vim.cmd([[%! ]] .. hex_dump_cmd .. " " .. vim.fn.expand('%:p'))
+  vim.cmd([[%! ]] .. hex_dump_cmd .. " \"" .. vim.fn.expand('%:p') .. "\"")
   vim.b.hex_ft = vim.bo.ft
   vim.bo.ft = 'xxd'
   M.drop_undo_history()


### PR DESCRIPTION
If the path to the file being edited contained a space xxd would try to open the file located at the path of everything before the first space in the actual file path (i.e. if you tried to edit `/home/user/path with space/binary-file.bin`, what xxd would try to open was `/home/user/path`).
This is a small PR that fixes that by adding quotes around the file path when executing.