### PR TITLE
fix: declare variables as `local`

### DIFF
--- a/lua/hex.lua
+++ b/lua/hex.lua
@@ -7,7 +7,7 @@ M.cfg = {
   dump_cmd = 'xxd -g 1 -u',
   assemble_cmd = 'xxd -r',
   is_file_binary_pre_read = function()
-    binary_ext = { 'out', 'bin', 'png', 'jpg', 'jpeg', 'exe', 'dll' }
+    local binary_ext = { 'out', 'bin', 'png', 'jpg', 'jpeg', 'exe', 'dll' }
     -- only work on normal buffers
     if vim.bo.ft ~= "" then return false end
     -- check -b flag
@@ -82,8 +82,8 @@ end
 M.setup = function(args)
   M.cfg = vim.tbl_deep_extend("force", M.cfg, args or {})
 
-  dump_program = vim.fn.split(M.cfg.dump_cmd)[1]
-  assemble_program = vim.fn.split(M.cfg.assemble_cmd)[1]
+  local dump_program = vim.fn.split(M.cfg.dump_cmd)[1]
+  local assemble_program = vim.fn.split(M.cfg.assemble_cmd)[1]
 
   if not u.is_program_executable(dump_program) then return end
   if not u.is_program_executable(assemble_program) then return end


### PR DESCRIPTION
`binary_ext`, `dump_program` and `assemble_program` variables were not marked `local` making them globally visible anywhere in neovim.